### PR TITLE
refactor: update `flake.nix` file and use `flake.parts`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lnl7",
-        "ref": "master",
-        "repo": "nix-darwin",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -54,19 +33,21 @@
         "type": "indirect"
       }
     },
-    "flake-utils": {
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "lastModified": 1678379998,
+        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
     "nix-phps": {
@@ -76,11 +57,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1678615004,
-        "narHash": "sha256-9DeBO55BacSo3OSrT21cFRqtnJ5hW2zt/OoHCnDgxNg=",
+        "lastModified": 1679198061,
+        "narHash": "sha256-eT5LMyG+pAv2jYBw9pyTtHv+F2mgrWjT+AfaHDiV9EM=",
         "owner": "fossar",
         "repo": "nix-phps",
-        "rev": "c9b73881b30b00d1c1be3b2522cb57c398de4f18",
+        "rev": "51ee70f76f42c7104bcd69575b60a253600a8e91",
         "type": "github"
       },
       "original": {
@@ -91,16 +72,16 @@
     },
     "nix-shell": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nix-phps": "nix-phps",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1678958699,
-        "narHash": "sha256-5ujsG7OQv64hsHDg2atI15HiGR3xdHdFLT9GgBwNSrY=",
+        "lastModified": 1679279134,
+        "narHash": "sha256-4EHE8Dp8cy4o60IaoQY/gRibWqhTjaDzGpkuzg3WikA=",
         "owner": "loophp",
         "repo": "nix-shell",
-        "rev": "7d752547e56111b7568fa985a56438da4d50ff7c",
+        "rev": "0aa6ac6c2ecfa7ba2f0ca7833a121a2d547da801",
         "type": "github"
       },
       "original": {
@@ -111,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678500213,
-        "narHash": "sha256-A5s2rXawJ+dCThkMXoMuYW8dgyUmkElcyfVJUot/Vr0=",
+        "lastModified": 1678987615,
+        "narHash": "sha256-lF4agoB7ysQGNHRXvOqxtSKIZrUZwClA85aASahQlYM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ce9b9842b5e63884dfc3dea6689769e2a1ea309",
+        "rev": "194c2aa446b2b059886bb68be15ef6736d5a8c31",
         "type": "github"
       },
       "original": {
@@ -143,13 +124,31 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1678594102,
-        "narHash": "sha256-OHAHYiMWJFPNxuW/PcOMlSD2tvXnEYC1jxREBADHwwQ=",
+        "dir": "lib",
+        "lastModified": 1678375444,
+        "narHash": "sha256-XIgHfGvjFvZQ8hrkfocanCDxMefc/77rXeHvYdzBMc8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "796b4a3c1d903c4b9270cd2548fe46f524eeb886",
+        "rev": "130fa0baaa2b93ec45523fdcde942f6844ee9f6e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1679198465,
+        "narHash": "sha256-VfXpHpniNWgg7pBzxb20pRX7kqn80LApPDQYTReiFCw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5a05160f7671434e1c833b1b01284b876e04eca4",
         "type": "github"
       },
       "original": {
@@ -177,19 +176,18 @@
     },
     "root": {
       "inputs": {
-        "darwin": "darwin",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nix-shell": "nix-shell",
         "nixpkgs": "nixpkgs_3"
       }
     },
     "utils": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,18 +4,29 @@
   inputs = {
     # Use fork until https://github.com/NixOS/nixpkgs/pull/221845 is merged
     nixpkgs.url = "github:lstrojny/nixpkgs/fix-php-wrapper";
-    darwin.url = "github:lnl7/nix-darwin/master";
-    darwin.inputs.nixpkgs.follows = "nixpkgs";
-    flake-utils.url = "github:numtide/flake-utils";
     nix-shell.url = "github:loophp/nix-shell";
   };
 
-  outputs = { self, nixpkgs, darwin, flake-utils, nix-shell }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
+  outputs = inputs @ {
+    self,
+    flake-parts,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      # This flake is for Linux (x86) and Apple (darwin) systems
+      # If you need more systems, inspect `nixpkgs.lib.systems.flakeExposed` and
+      # add them to this list.
+      #
+      # $ nix repl "<nixpkgs>"
+      # nix-repl> lib.systems.flakeExposed
+      systems = ["x86_64-linux" "aarch64-linux"];
 
-        php = (nix-shell.api.makePhp system {
+      perSystem = {
+        pkgs,
+        system,
+        ...
+      }: let
+        php = inputs.nix-shell.api.makePhp system {
           php = "php82";
           withExtensions = [
             "xdebug"
@@ -36,20 +47,22 @@
           extraConfig = ''
             xdebug.mode = coverage
           '';
-        });
-      in {
-        devShells = {
-          default = pkgs.mkShellNoCC {
-            name = "ufff";
-
-            buildInputs = [
-              php
-              php.packages.composer
-              pkgs.mailhog
-              pkgs.sphinx
-              (pkgs.python3.withPackages (p: with p; [ sphinx-rtd-theme ]))
-            ];
-          };
         };
-      });
+      in {
+        # Run `nix fmt` to reformat the nix files
+        formatter = pkgs.alejandra;
+
+        devShells.default = pkgs.mkShellNoCC {
+          name = "ufff";
+
+          buildInputs = [
+            php
+            php.packages.composer
+            pkgs.mailhog
+            pkgs.sphinx
+            (pkgs.python3.withPackages (p: with p; [ sphinx-rtd-theme ]))
+          ];
+        };
+      };
+    };
 }


### PR DESCRIPTION
This PR:

- ` flake.parts` replaces `flake-utils`. This is a better practice to use it. 
- I also removed inputs that were not really used.
- I guess you can remove the package like `mailhog`, which is not really needed in this context?