### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,3 +3,6 @@ version: 2
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
+
+build:
+  os: ubuntu-22.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,3 +6,5 @@ sphinx:
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.10"


### PR DESCRIPTION
Configuring `build.os` became mandatory, so did specifying at least one tools. The [blog post](https://blog.readthedocs.com/use-build-os-config/) does not mention "build.tools" and an entirely different timeline but it is what it is.